### PR TITLE
chore: add classname attribute to testcase tag

### DIFF
--- a/junit.js
+++ b/junit.js
@@ -14,7 +14,9 @@ function generateJUnitXML(data, options) {
   const name =
     options && options.name ? escapeHTML(options.name) : 'k6 thresholds';
   const classname =
-    options && options.classname ? escapeHTML(options.classname) : '';
+    options && options.classname
+      ? escapeHTML(options.classname)
+      : 'Unnamed folder';
   let failures = 0;
   let cases = [];
 

--- a/junit.js
+++ b/junit.js
@@ -14,7 +14,7 @@ function generateJUnitXML(data, options) {
   const name =
     options && options.name ? escapeHTML(options.name) : 'k6 thresholds';
   const classname =
-    options && options.classname ? escapeHTML(options.classname) : 'undefined';
+    options && options.classname ? escapeHTML(options.classname) : '';
   let failures = 0;
   let cases = [];
 

--- a/junit.js
+++ b/junit.js
@@ -11,6 +11,10 @@ function escapeHTML(str) {
 }
 
 function generateJUnitXML(data, options) {
+  const name =
+    options && options.name ? escapeHTML(options.name) : 'k6 thresholds';
+  const classname =
+    options && options.classname ? escapeHTML(options.classname) : 'undefined';
   let failures = 0;
   let cases = [];
 
@@ -19,32 +23,30 @@ function generateJUnitXML(data, options) {
       return;
     }
     Object.entries(metric.thresholds).forEach(([thresholdName, threshold]) => {
+      const testcaseName = `${escapeHTML(metricName)} - ${escapeHTML(
+        thresholdName,
+      )}`;
+
       if (threshold.ok) {
         cases.push(
-          `<testcase name="${escapeHTML(metricName)} - ${escapeHTML(
-            thresholdName,
-          )}" />`,
+          `<testcase name="${testcaseName}" classname="${classname}" />`,
         );
       } else {
         failures++;
         const failureMessage =
-          `"><failure message="${metric.type} threshold failed: ` +
+          `${metric.type} threshold failed: ` +
           Object.entries(metric.values)
             .map(([key, value]) => `${key} value: ${value}`)
-            .join(', ') +
-          '"/></testcase>';
+            .join(', ');
 
         cases.push(
-          `<testcase name="${escapeHTML(metricName)} - ${escapeHTML(
-            thresholdName,
-          )}${failureMessage}"`,
+          `<testcase name="${testcaseName}" classname="${classname}"><failure message="${escapeHTML(
+            failureMessage,
+          )}" /></testcase>`,
         );
       }
     });
   });
-
-  const name =
-    options && options.name ? escapeHTML(options.name) : 'k6 thresholds';
 
   return `<?xml version="1.0"?>
     <testsuites tests="${cases.length}" failures="${failures}">


### PR DESCRIPTION
Some jUnit parsers need `classname` attribute in order to group the test results.