### PR TITLE
Disable cache for actions/setup-node

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
+          package-manager-cache: false
       - name: Dependencies
         run: yarn
       - name: Lint Code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
+          package-manager-cache: false
       - name: Dependencies
         run: yarn
       - name: Check build & archive build


### PR DESCRIPTION
This fixes a vulnerability spotted by zizmor:
```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> ./.github/workflows/release.yml:19:9
   |
 3 | / on:
 4 | |   push:
 5 | |     tags:
 6 | |       - v*
   | |__________- generally used when publishing artifacts generated at runtime
...
19 |           uses: actions/setup-node@v4
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
   |
   = note: audit confidence → Low

8 findings (7 suppressed): 0 informational, 0 low, 0 medium, 1 high
```