### PR TITLE
build: pin package manager and disable automatic install-time lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-scripts true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
-    "name": "k6-jslib-summary",
-    "repository": "https://github.com/grafana/k6-jslib-summary",
-    "version": "0.0.5",
-    "description": "Creates a summary of the k6 JS libraries used in a test runs.",
-    "devDependencies": {
-        "esbuild": "0.28.0",
-        "eslint": "8.57.1",
-        "eslint-config-prettier": "10.1.8",
-        "eslint-plugin-prettier": "5.5.5",
-        "prettier": "3.8.3"
-    },
-    "engines": {},
-    "scripts": {
-        "lint": "eslint --max-warnings 0 src",
-        "fix": "eslint --fix src",
-        "build": "esbuild ./src/index.js --bundle --sourcemap --minify --format=cjs --legal-comments=none --outfile=./build/index.js"
-    },
-    "keywords": [
-        "k6"
-    ],
-    "author": "grafana/k6 team",
-    "license": "Apache-2.0"
+  "name": "k6-jslib-summary",
+  "repository": "https://github.com/grafana/k6-jslib-summary",
+  "version": "0.0.5",
+  "packageManager": "npm@10.9.2",
+  "description": "Creates a summary of the k6 JS libraries used in a test runs.",
+  "devDependencies": {
+    "esbuild": "0.28.0",
+    "eslint": "8.57.1",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-prettier": "5.5.5",
+    "prettier": "3.8.3"
+  },
+  "engines": {},
+  "scripts": {
+    "lint": "eslint --max-warnings 0 src",
+    "fix": "eslint --fix src",
+    "build": "esbuild ./src/index.js --bundle --sourcemap --minify --format=cjs --legal-comments=none --outfile=./build/index.js"
+  },
+  "keywords": [
+    "k6"
+  ],
+  "author": "grafana/k6 team",
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Disables automatic execution of npm/yarn install-time lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`, ...) so a malicious or compromised transitive dependency cannot run arbitrary code during `npm install` / `yarn install`. Manually invoked scripts (`npm run ...`, `yarn ...`) are unaffected — only auto-execution at install time is blocked.

Writes all three package-manager config files at the repo root, regardless of which manager the repo currently uses. Defense in depth: each file is read only by its own tool, so writing all three costs nothing and guards against npm, Yarn Classic, and Yarn Berry equally.
- `.npmrc` → `ignore-scripts=true` (npm, also honored by Yarn Classic)
- `.yarnrc` → `ignore-scripts true` (Yarn Classic, explicit)
- `.yarnrc.yml` → `enableScripts: false` (Yarn Berry; does not read `.npmrc`)

Pins the package manager via `packageManager` in `package.json` so Corepack uses a known version.